### PR TITLE
fix(html-nano): set svg minification to false

### DIFF
--- a/.htmlnanorc
+++ b/.htmlnanorc
@@ -1,0 +1,3 @@
+{
+    "minifySvg": false
+}


### PR DESCRIPTION
Apparently the html-nano plugin for the parcel bundler has a svg minification process that stripped out the viewBox attribute and whatever was messing up the calendar icon. Set to false for the fix.

https://github.com/parcel-bundler/parcel/issues/1523

RJE-15 RJE-14